### PR TITLE
Remove transitive dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# V0.4.6
+- Remove transitive dependencies
+
 # V0.4.5
 - Use inmanta-dev-dependencies package
 

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 name: docker
 description: Module to manage docker based containers
-version: 0.4.5
+version: 0.4.6.dev1606909602
 license: Apache 2.0
 author: Inmanta <code@inmanta.com>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,2 @@
 docker-py==1.10.6
 
-certifi==2020.11.8
-chardet==3.0.4
-docker-pycreds==0.4.0
-idna==2.10
-requests==2.25.0
-six==1.15.0
-urllib3==1.26.2
-websocket-client==0.57.0


### PR DESCRIPTION
The transitive dependencies should have all been removed earlier (my bad), but some weren't, and they are causing compatibility issues with the new pip resolver.